### PR TITLE
refactor: +page.tsでDuelStateクラスを使用するように変更

### DIFF
--- a/skeleton-app/src/routes/(auth)/simulator/[deckId]/+page.svelte
+++ b/skeleton-app/src/routes/(auth)/simulator/[deckId]/+page.svelte
@@ -6,7 +6,8 @@
 
   export let data: PageData;
 
-  $: ({ gameState } = data);
+  $: ({ duelState } = data);
+  $: duelStats = duelState.getDuelStats();
 </script>
 
 <div class="container mx-auto p-4">
@@ -14,19 +15,19 @@
     <div class="grid grid-cols-6 gap-2 md:gap-2 sm:gap-1">
       <div class="col-span-5">
         <DuelField
-          deckCards={gameState.deckCards}
-          extraDeckCards={gameState.extraDeckCards}
-          graveyardCards={gameState.graveyardCards}
+          deckCards={duelStats.mainDeckRemaining}
+          extraDeckCards={duelStats.extraDeckRemaining}
+          graveyardCards={duelStats.graveyardSize}
         />
-        <Hands handCards={gameState.handCards} />
+        <Hands handCards={duelStats.handsSize} />
       </div>
       <div class="col-span-1 p-4">
         <GameInfo
-          deckName={gameState.sourceRecipe}
-          playerLifePoints={gameState.playerLifePoints}
-          opponentLifePoints={gameState.opponentLifePoints}
-          currentTurn={gameState.currentTurn}
-          currentPhase={gameState.currentPhase}
+          deckName={duelState.sourceRecipe || ""}
+          playerLifePoints={8000}
+          opponentLifePoints={8000}
+          currentTurn={1}
+          currentPhase="メインフェイズ1"
         />
       </div>
     </div>

--- a/skeleton-app/src/routes/(auth)/simulator/[deckId]/+page.ts
+++ b/skeleton-app/src/routes/(auth)/simulator/[deckId]/+page.ts
@@ -1,27 +1,23 @@
 import type { PageLoad } from "./$types";
 import { loadDeckData } from "$lib/utils/deckLoader";
+import { DuelState } from "$lib/classes/DuelState";
+import { DeckRecipe } from "$lib/classes/DeckRecipe";
 
 export const load: PageLoad = async ({ params, fetch }) => {
   const { deckId } = params;
 
-  const deck = await loadDeckData(deckId, fetch);
+  const deckData = await loadDeckData(deckId, fetch);
+  const deck = new DeckRecipe(deckData);
 
-  // ゲーム初期状態を作成
-  const gameState = {
-    playerLifePoints: 8000,
-    opponentLifePoints: 8000,
-    currentTurn: 1,
-    currentPhase: "メインフェイズ1",
-    handCards: 5,
-    deckCards: deck.mainDeck.length,
-    extraDeckCards: deck.extraDeck.length,
-    graveyardCards: 0,
-    sourceRecipe: deck.name,
-  };
+  // DuelStateクラスを使用してゲーム初期状態を作成
+  const duelState = DuelState.loadRecipe(deck);
+
+  // 初期手札をドロー
+  duelState.drawInitialHands();
 
   return {
     deck,
-    gameState,
+    duelState,
     deckId,
   };
 };


### PR DESCRIPTION
## Summary
- gameStateをDuelStateクラスのインスタンスに置き換え
- 表示コンポーネントでDuelStateから適切な値を取得するように修正
- DuelStats統計情報を活用してゲーム状態を表示

## Test plan
- [x] TypeScript型チェック実行
- [x] ESLint + Prettier実行
- [x] フォーマット済み

🤖 Generated with [Claude Code](https://claude.ai/code)