### PR TITLE
feat: CardとCardDataインターフェースを分離

### DIFF
--- a/skeleton-app/src/lib/components/atoms/Card.svelte
+++ b/skeleton-app/src/lib/components/atoms/Card.svelte
@@ -31,7 +31,7 @@
   }: CardComponentProps = $props();
 
   let isHovered = $state(false);
-  let isSelected = $state(card?.ui?.isSelected || false);
+  let isSelected = $state(card?.isSelected || false);
 
   // サイズクラスの定義
   const sizeClasses = {
@@ -47,10 +47,7 @@
     }
     if (selectable) {
       isSelected = !isSelected;
-      if (card) {
-        if (!card.ui) card.ui = {};
-        card.ui.isSelected = isSelected;
-      }
+      if (card) card.isSelected = isSelected;
     }
   }
 

--- a/skeleton-app/src/lib/components/atoms/Card.svelte
+++ b/skeleton-app/src/lib/components/atoms/Card.svelte
@@ -1,6 +1,20 @@
 <script lang="ts">
-  import type { CardComponentProps } from "$lib/types/card";
+  import type { Card } from "$lib/types/card";
   import cardBackImage from "$lib/assets/CardBack.jpg";
+
+  interface CardComponentProps {
+    card?: Card;
+    size?: "small" | "medium" | "large";
+    showDetails?: boolean;
+    clickable?: boolean;
+    selectable?: boolean;
+    placeholder?: boolean;
+    placeholderText?: string;
+    rotation?: number;
+    animate?: boolean;
+    onClick?: (card: Card) => void;
+    onHover?: (card: Card | null) => void;
+  }
 
   let {
     card,

--- a/skeleton-app/src/lib/types/card.ts
+++ b/skeleton-app/src/lib/types/card.ts
@@ -33,7 +33,7 @@ export interface CardData {
   images?: CardImageProperties;
 }
 
-// ゲームで動的なカードインスタンス用のインターフェース
+// ゲームで使用する動的なカードインスタンス用のインターフェース
 export interface Card extends CardData {
   isSelected?: boolean;
   position?: "attack" | "defense" | "facedown";

--- a/skeleton-app/src/lib/types/card.ts
+++ b/skeleton-app/src/lib/types/card.ts
@@ -1,8 +1,6 @@
-// カードタイプの定義
 export type CardType = "monster" | "spell" | "trap";
 
-// モンスターカード専用のプロパティ
-export interface MonsterCardProperties {
+interface MonsterCardProperties {
   attack?: number;
   defense?: number;
   level?: number;
@@ -10,21 +8,13 @@ export interface MonsterCardProperties {
   race?: string;
 }
 
-// カード画像のプロパティ
-export interface CardImageProperties {
+interface CardImageProperties {
   image?: string; // URL to card image
   imageSmall?: string; // URL to small card image
   imageCropped?: string; // URL to cropped card image
 }
 
-// UI用のプロパティ
-export interface CardUIProperties {
-  isSelected?: boolean;
-  position?: "attack" | "defense" | "facedown";
-  quantity?: number; // デッキ内での枚数
-}
-
-// 静的なカードのデータ（APIから取得される不変のデータ）
+// 静的なカードデータ
 export interface CardData {
   // 必須プロパティ
   id: number; // YGOPRODeck API uses numeric IDs
@@ -43,8 +33,9 @@ export interface CardData {
   images?: CardImageProperties;
 }
 
-// ゲーム内で利用する動的なカードインスタンス
+// ゲームで動的なカードインスタンス用のインターフェース
 export interface Card extends CardData {
-  // UI用プロパティ（動的な状態を含む）
-  ui?: CardUIProperties;
+  isSelected?: boolean;
+  position?: "attack" | "defense" | "facedown";
+  quantity?: number; // デッキ内での枚数
 }

--- a/skeleton-app/src/lib/types/card.ts
+++ b/skeleton-app/src/lib/types/card.ts
@@ -48,17 +48,3 @@ export interface Card extends CardData {
   // UI用プロパティ（動的な状態を含む）
   ui?: CardUIProperties;
 }
-
-export interface CardComponentProps {
-  card?: Card;
-  size?: "small" | "medium" | "large";
-  showDetails?: boolean;
-  clickable?: boolean;
-  selectable?: boolean;
-  placeholder?: boolean;
-  placeholderText?: string;
-  rotation?: number;
-  animate?: boolean;
-  onClick?: (card: Card) => void;
-  onHover?: (card: Card | null) => void;
-}

--- a/skeleton-app/src/lib/types/card.ts
+++ b/skeleton-app/src/lib/types/card.ts
@@ -24,8 +24,8 @@ export interface CardUIProperties {
   quantity?: number; // デッキ内での枚数
 }
 
-// 基本のCardインターフェース
-export interface Card {
+// 静的なカードのデータ（APIから取得される不変のデータ）
+export interface CardData {
   // 必須プロパティ
   id: number; // YGOPRODeck API uses numeric IDs
   name: string;
@@ -41,8 +41,11 @@ export interface Card {
 
   // 画像プロパティ
   images?: CardImageProperties;
+}
 
-  // UI用プロパティ
+// ゲーム内で利用する動的なカードインスタンス
+export interface Card extends CardData {
+  // UI用プロパティ（動的な状態を含む）
   ui?: CardUIProperties;
 }
 


### PR DESCRIPTION
## Summary
- 静的なカードデータ（CardData）とゲーム内で利用する動的なカードインスタンス（Card）を分離
- CardData: APIから取得される不変のデータ（id、name、type、descriptionなど）
- Card: CardDataを拡張し、UI用の動的な状態（isSelected、positionなど）を追加

## Test plan
- [x] 型チェック実行（npm run check）
- [x] リンター実行（npm run lint）
- [x] ルートの競合エラーを解決

🤖 Generated with [Claude Code](https://claude.ai/code)