### PR TITLE
refactor: DeckDataを最適化してCardDataと枚数を分離管理

### DIFF
--- a/skeleton-app/src/lib/classes/DuelState.ts
+++ b/skeleton-app/src/lib/classes/DuelState.ts
@@ -53,9 +53,9 @@ export class DuelState {
    */
   private static expandLoadedCardEntries(loadedCardEntries: LoadedCardEntry[]): Card[] {
     const cards: Card[] = [];
-    for (const { card, quantity } of loadedCardEntries) {
+    for (const { cardData, quantity } of loadedCardEntries) {
       for (let i = 0; i < quantity; i++) {
-        cards.push({ ...card });
+        cards.push({ ...cardData });
       }
     }
     return cards;

--- a/skeleton-app/src/lib/classes/DuelState.ts
+++ b/skeleton-app/src/lib/classes/DuelState.ts
@@ -1,6 +1,6 @@
 import type { Card } from "$lib/types/card";
 import type { DuelStateData, DuelStats } from "$lib/types/duel";
-import type { DeckData, DeckCardData } from "$lib/types/deck";
+import type { DeckData, LoadedCardEntry } from "$lib/types/deck";
 
 /**
  * ゲーム状態管理クラス
@@ -49,11 +49,11 @@ export class DuelState {
   }
 
   /**
-   * DeckCardDataをCard配列に展開するヘルパー関数
+   * LoadedCardEntryをCard配列に展開するヘルパー関数
    */
-  private static expandDeckCardData(deckCardData: DeckCardData[]): Card[] {
+  private static expandLoadedCardEntries(loadedCardEntries: LoadedCardEntry[]): Card[] {
     const cards: Card[] = [];
-    for (const { card, quantity } of deckCardData) {
+    for (const { card, quantity } of loadedCardEntries) {
       for (let i = 0; i < quantity; i++) {
         cards.push({ ...card });
       }
@@ -67,8 +67,8 @@ export class DuelState {
   static loadDeck(deckData: DeckData, name?: string): DuelState {
     return new DuelState({
       name: name || deckData.name,
-      mainDeck: this.expandDeckCardData(deckData.mainDeck),
-      extraDeck: this.expandDeckCardData(deckData.extraDeck),
+      mainDeck: this.expandLoadedCardEntries(deckData.mainDeck),
+      extraDeck: this.expandLoadedCardEntries(deckData.extraDeck),
       sourceRecipe: deckData.name,
     });
   }

--- a/skeleton-app/src/lib/classes/DuelState.ts
+++ b/skeleton-app/src/lib/classes/DuelState.ts
@@ -1,6 +1,6 @@
 import type { Card } from "$lib/types/card";
 import type { DuelStateData, DuelStats } from "$lib/types/duel";
-import type { DeckData } from "$lib/types/deck";
+import type { DeckData, DeckCardData } from "$lib/types/deck";
 
 /**
  * ゲーム状態管理クラス
@@ -49,13 +49,26 @@ export class DuelState {
   }
 
   /**
+   * DeckCardDataをCard配列に展開するヘルパー関数
+   */
+  private static expandDeckCardData(deckCardData: DeckCardData[]): Card[] {
+    const cards: Card[] = [];
+    for (const { card, quantity } of deckCardData) {
+      for (let i = 0; i < quantity; i++) {
+        cards.push({ ...card });
+      }
+    }
+    return cards;
+  }
+
+  /**
    * デッキレシピをロードしてインスタンスを作成
    */
   static loadDeck(deckData: DeckData, name?: string): DuelState {
     return new DuelState({
       name: name || deckData.name,
-      mainDeck: [...deckData.mainDeck],
-      extraDeck: [...deckData.extraDeck],
+      mainDeck: this.expandDeckCardData(deckData.mainDeck),
+      extraDeck: this.expandDeckCardData(deckData.extraDeck),
       sourceRecipe: deckData.name,
     });
   }

--- a/skeleton-app/src/lib/classes/__tests__/DuelState.test.ts
+++ b/skeleton-app/src/lib/classes/__tests__/DuelState.test.ts
@@ -1,17 +1,17 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { DuelState } from "../DuelState";
-import type { Card } from "$lib/types/card";
-import type { DeckData } from "$lib/types/deck";
+import type { CardData } from "$lib/types/card";
+import type { DeckData, DeckCardData } from "$lib/types/deck";
 
 describe("DuelState", () => {
   let duelState: DuelState;
   let deckData: DeckData;
-  let sampleCard: Card;
-  let monsterCard: Card;
-  let spellCard: Card;
+  let sampleCardData: CardData;
+  let monsterCardData: CardData;
+  let spellCardData: CardData;
 
   beforeEach(() => {
-    sampleCard = {
+    sampleCardData = {
       id: 1001,
       name: "テストカード",
       type: "monster",
@@ -23,12 +23,9 @@ describe("DuelState", () => {
         attribute: "LIGHT",
         race: "Warrior",
       },
-      ui: {
-        quantity: 1,
-      },
     };
 
-    monsterCard = {
+    monsterCardData = {
       id: 2001,
       name: "テストモンスター",
       type: "monster",
@@ -40,25 +37,22 @@ describe("DuelState", () => {
         attribute: "DARK",
         race: "Dragon",
       },
-      ui: {
-        quantity: 1,
-      },
     };
 
-    spellCard = {
+    spellCardData = {
       id: 3001,
       name: "テスト魔法",
       type: "spell",
       description: "テスト用の魔法カード",
-      ui: {
-        quantity: 1,
-      },
     };
 
-    // サンプルレシピを作成
-    const mainDeck = Array(40)
+    // サンプルレシピを作成（DeckCardData形式）
+    const mainDeck: DeckCardData[] = Array(40)
       .fill(null)
-      .map((_, i) => ({ ...sampleCard, id: 5000 + i, name: `カード${i}` }));
+      .map((_, i) => ({
+        card: { ...sampleCardData, id: 5000 + i, name: `カード${i}` },
+        quantity: 1,
+      }));
 
     deckData = {
       name: "テストデッキ",
@@ -105,7 +99,7 @@ describe("DuelState", () => {
       // デッキにカードを追加
       const cards = [];
       for (let i = 0; i < 10; i++) {
-        const card = { ...sampleCard, id: 6000 + i, name: `シャッフルカード${i}` };
+        const card = { ...sampleCardData, id: 6000 + i, name: `シャッフルカード${i}` };
         cards.push(card);
         duelState.mainDeck.push(card);
       }
@@ -126,7 +120,7 @@ describe("DuelState", () => {
     beforeEach(() => {
       // デッキに5枚追加
       for (let i = 0; i < 5; i++) {
-        duelState.mainDeck.push({ ...sampleCard, id: 7000 + i });
+        duelState.mainDeck.push({ ...sampleCardData, id: 7000 + i });
       }
     });
 
@@ -159,7 +153,7 @@ describe("DuelState", () => {
   describe("drawInitialHands", () => {
     beforeEach(() => {
       for (let i = 0; i < 10; i++) {
-        duelState.mainDeck.push({ ...sampleCard, id: 8000 + i });
+        duelState.mainDeck.push({ ...sampleCardData, id: 8000 + i });
       }
     });
 
@@ -182,31 +176,31 @@ describe("DuelState", () => {
 
   describe("summonToField", () => {
     beforeEach(() => {
-      duelState.hands.push(monsterCard);
-      duelState.hands.push(spellCard);
+      duelState.hands.push({ ...monsterCardData });
+      duelState.hands.push({ ...spellCardData });
     });
 
     it("should summon monster to monster zone", () => {
-      const result = duelState.summonToField(monsterCard.id, "monster");
+      const result = duelState.summonToField(monsterCardData.id, "monster");
 
       expect(result).toBe(true);
-      expect(duelState.field.monsterZones[0]).toEqual(monsterCard);
+      expect(duelState.field.monsterZones[0]).toEqual({ ...monsterCardData });
       expect(duelState.hands).toHaveLength(1); // spellCardのみ残る
     });
 
     it("should place spell in spell/trap zone", () => {
-      const result = duelState.summonToField(spellCard.id, "spellTrap");
+      const result = duelState.summonToField(spellCardData.id, "spellTrap");
 
       expect(result).toBe(true);
-      expect(duelState.field.spellTrapZones[0]).toEqual(spellCard);
+      expect(duelState.field.spellTrapZones[0]).toEqual({ ...spellCardData });
       expect(duelState.hands).toHaveLength(1); // monsterCardのみ残る
     });
 
     it("should place card in specific zone", () => {
-      const result = duelState.summonToField(monsterCard.id, "monster", 2);
+      const result = duelState.summonToField(monsterCardData.id, "monster", 2);
 
       expect(result).toBe(true);
-      expect(duelState.field.monsterZones[2]).toEqual(monsterCard);
+      expect(duelState.field.monsterZones[2]).toEqual({ ...monsterCardData });
       expect(duelState.field.monsterZones[0]).toBeNull();
     });
 
@@ -218,26 +212,26 @@ describe("DuelState", () => {
 
   describe("sendToGraveyard", () => {
     beforeEach(() => {
-      duelState.hands.push(sampleCard);
-      duelState.field.monsterZones[0] = monsterCard;
+      duelState.hands.push({ ...sampleCardData });
+      duelState.field.monsterZones[0] = { ...monsterCardData };
     });
 
     it("should send card from hand to graveyard", () => {
-      const result = duelState.sendToGraveyard(sampleCard.id, "hand");
+      const result = duelState.sendToGraveyard(sampleCardData.id, "hand");
 
       expect(result).toBe(true);
       expect(duelState.hands).toHaveLength(0);
       expect(duelState.graveyard).toHaveLength(1);
-      expect(duelState.graveyard[0]).toEqual(sampleCard);
+      expect(duelState.graveyard[0]).toEqual({ ...sampleCardData });
     });
 
     it("should send card from field to graveyard", () => {
-      const result = duelState.sendToGraveyard(monsterCard.id, "field");
+      const result = duelState.sendToGraveyard(monsterCardData.id, "field");
 
       expect(result).toBe(true);
       expect(duelState.field.monsterZones[0]).toBeNull();
       expect(duelState.graveyard).toHaveLength(1);
-      expect(duelState.graveyard[0]).toEqual(monsterCard);
+      expect(duelState.graveyard[0]).toEqual({ ...monsterCardData });
     });
 
     it("should return false for non-existent card", () => {
@@ -248,26 +242,26 @@ describe("DuelState", () => {
 
   describe("banishCard", () => {
     beforeEach(() => {
-      duelState.hands.push(sampleCard);
-      duelState.graveyard.push(monsterCard);
+      duelState.hands.push({ ...sampleCardData });
+      duelState.graveyard.push({ ...monsterCardData });
     });
 
     it("should banish card from hand", () => {
-      const result = duelState.banishCard(sampleCard.id, "hand");
+      const result = duelState.banishCard(sampleCardData.id, "hand");
 
       expect(result).toBe(true);
       expect(duelState.hands).toHaveLength(0);
       expect(duelState.banished).toHaveLength(1);
-      expect(duelState.banished[0]).toEqual(sampleCard);
+      expect(duelState.banished[0]).toEqual({ ...sampleCardData });
     });
 
     it("should banish card from graveyard", () => {
-      const result = duelState.banishCard(monsterCard.id, "graveyard");
+      const result = duelState.banishCard(monsterCardData.id, "graveyard");
 
       expect(result).toBe(true);
       expect(duelState.graveyard).toHaveLength(0);
       expect(duelState.banished).toHaveLength(1);
-      expect(duelState.banished[0]).toEqual(monsterCard);
+      expect(duelState.banished[0]).toEqual({ ...monsterCardData });
     });
   });
 
@@ -275,14 +269,14 @@ describe("DuelState", () => {
     beforeEach(() => {
       // セットアップ
       for (let i = 0; i < 30; i++) {
-        duelState.mainDeck.push({ ...sampleCard, id: 9000 + i });
+        duelState.mainDeck.push({ ...sampleCardData, id: 9000 + i });
       }
       for (let i = 0; i < 10; i++) {
-        duelState.extraDeck.push({ ...sampleCard, id: 9500 + i });
+        duelState.extraDeck.push({ ...sampleCardData, id: 9500 + i });
       }
-      duelState.hands.push(sampleCard);
-      duelState.graveyard.push(monsterCard);
-      duelState.field.monsterZones[0] = spellCard;
+      duelState.hands.push({ ...sampleCardData });
+      duelState.graveyard.push({ ...monsterCardData });
+      duelState.field.monsterZones[0] = { ...spellCardData };
     });
 
     it("should return correct game statistics", () => {
@@ -301,10 +295,10 @@ describe("DuelState", () => {
 
   describe("reset", () => {
     beforeEach(() => {
-      duelState.hands.push(sampleCard);
-      duelState.graveyard.push(monsterCard);
-      duelState.field.monsterZones[0] = spellCard;
-      duelState.mainDeck.push({ ...sampleCard, id: 10000 });
+      duelState.hands.push({ ...sampleCardData });
+      duelState.graveyard.push({ ...monsterCardData });
+      duelState.field.monsterZones[0] = { ...spellCardData };
+      duelState.mainDeck.push({ ...sampleCardData, id: 10000 });
     });
 
     it("should reset duel state to initial state", () => {
@@ -322,8 +316,8 @@ describe("DuelState", () => {
   describe("JSON serialization", () => {
     beforeEach(() => {
       duelState.name = "テスト決闘状態";
-      duelState.mainDeck.push(sampleCard);
-      duelState.hands.push(monsterCard);
+      duelState.mainDeck.push({ ...sampleCardData });
+      duelState.hands.push({ ...monsterCardData });
     });
 
     it("should serialize to JSON", () => {
@@ -350,7 +344,7 @@ describe("DuelState", () => {
   describe("clone", () => {
     beforeEach(() => {
       duelState.name = "オリジナル";
-      duelState.mainDeck.push(sampleCard);
+      duelState.mainDeck.push({ ...sampleCardData });
     });
 
     it("should create a deep copy", () => {

--- a/skeleton-app/src/lib/classes/__tests__/DuelState.test.ts
+++ b/skeleton-app/src/lib/classes/__tests__/DuelState.test.ts
@@ -50,7 +50,7 @@ describe("DuelState", () => {
     const mainDeck: LoadedCardEntry[] = Array(40)
       .fill(null)
       .map((_, i) => ({
-        card: { ...sampleCardData, id: 5000 + i, name: `カード${i}` },
+        cardData: { ...sampleCardData, id: 5000 + i, name: `カード${i}` },
         quantity: 1,
       }));
 

--- a/skeleton-app/src/lib/classes/__tests__/DuelState.test.ts
+++ b/skeleton-app/src/lib/classes/__tests__/DuelState.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { DuelState } from "../DuelState";
 import type { CardData } from "$lib/types/card";
-import type { DeckData, DeckCardData } from "$lib/types/deck";
+import type { DeckData, LoadedCardEntry } from "$lib/types/deck";
 
 describe("DuelState", () => {
   let duelState: DuelState;
@@ -46,8 +46,8 @@ describe("DuelState", () => {
       description: "テスト用の魔法カード",
     };
 
-    // サンプルレシピを作成（DeckCardData形式）
-    const mainDeck: DeckCardData[] = Array(40)
+    // サンプルレシピを作成（LoadedCardEntry形式）
+    const mainDeck: LoadedCardEntry[] = Array(40)
       .fill(null)
       .map((_, i) => ({
         card: { ...sampleCardData, id: 5000 + i, name: `カード${i}` },
@@ -58,6 +58,13 @@ describe("DuelState", () => {
       name: "テストデッキ",
       mainDeck,
       extraDeck: [],
+      stats: {
+        totalCards: 40,
+        uniqueCards: 40,
+        monsterCount: 40,
+        spellCount: 0,
+        trapCount: 0,
+      },
     };
 
     duelState = new DuelState();

--- a/skeleton-app/src/lib/types/card.ts
+++ b/skeleton-app/src/lib/types/card.ts
@@ -14,7 +14,11 @@ interface CardImageProperties {
   imageCropped?: string; // URL to cropped card image
 }
 
-// 静的なカードデータ
+/**
+ * 静的なカードマスターデータ
+ * APIから取得される不変のカード情報を表現
+ * デッキレシピやカードデータベースで使用
+ */
 export interface CardData {
   // 必須プロパティ
   id: number; // YGOPRODeck API uses numeric IDs
@@ -33,9 +37,12 @@ export interface CardData {
   images?: CardImageProperties;
 }
 
-// ゲームで使用する動的なカードインスタンス用のインターフェース
+/**
+ * ゲーム内で使用する動的なカードインスタンス
+ * CardDataにゲーム状態（選択状態、フィールド上の位置など）を追加
+ * 実際のデュエル中にのみ使用
+ */
 export interface Card extends CardData {
-  isSelected?: boolean;
-  position?: "attack" | "defense" | "facedown";
-  quantity?: number; // デッキ内での枚数
+  isSelected?: boolean; // UI上での選択状態
+  position?: "attack" | "defense" | "facedown"; // フィールド上での表示形式
 }

--- a/skeleton-app/src/lib/types/deck.ts
+++ b/skeleton-app/src/lib/types/deck.ts
@@ -15,7 +15,7 @@ export interface RecipeCardEntry {
  * UI表示やゲーム処理で使用
  */
 export interface LoadedCardEntry {
-  card: CardData; // カードの静的データ
+  cardData: CardData; // カードの静的データ
   quantity: number; // 枚数
 }
 

--- a/skeleton-app/src/lib/types/deck.ts
+++ b/skeleton-app/src/lib/types/deck.ts
@@ -1,8 +1,14 @@
-import type { Card } from "$lib/types/card";
+import type { CardData } from "$lib/types/card";
 
 // カード ID と枚数の組み合わせ
 export interface DeckCardEntry {
   id: number; // YGOPRODeck API の数値 ID
+  quantity: number; // 枚数
+}
+
+// CardData と枚数の組み合わせ
+export interface DeckCardData {
+  card: CardData; // カードの静的データ
   quantity: number; // 枚数
 }
 
@@ -21,7 +27,7 @@ export interface DeckRecipe extends DeckBase {
 
 // デッキレシピをロードして作成するデッキデータ
 export interface DeckData extends DeckBase {
-  // Card オブジェクトを保持
-  mainDeck: Card[];
-  extraDeck: Card[];
+  // CardData と枚数を保持（同名カードの重複インスタンスを避ける）
+  mainDeck: DeckCardData[];
+  extraDeck: DeckCardData[];
 }

--- a/skeleton-app/src/lib/types/deck.ts
+++ b/skeleton-app/src/lib/types/deck.ts
@@ -1,15 +1,33 @@
 import type { CardData } from "$lib/types/card";
 
-// カード ID と枚数の組み合わせ
-export interface DeckCardEntry {
+/**
+ * レシピ保存時のカードエントリー（ID + 枚数）
+ * データベースやJSONファイルに保存する軽量な形式
+ */
+export interface RecipeCardEntry {
   id: number; // YGOPRODeck API の数値 ID
   quantity: number; // 枚数
 }
 
-// CardData と枚数の組み合わせ
-export interface DeckCardData {
+/**
+ * ロード済みカードエントリー（CardData + 枚数）
+ * APIからロードしたカードデータと枚数の組み合わせ
+ * UI表示やゲーム処理で使用
+ */
+export interface LoadedCardEntry {
   card: CardData; // カードの静的データ
   quantity: number; // 枚数
+}
+
+/**
+ * デッキ統計情報
+ */
+export interface DeckStats {
+  totalCards: number; // 総カード数
+  monsterCount: number; // モンスターカード数
+  spellCount: number; // 魔法カード数
+  trapCount: number; // 罠カード数
+  uniqueCards: number; // ユニークカード種類数
 }
 
 interface DeckBase {
@@ -18,16 +36,22 @@ interface DeckBase {
   category?: string;
 }
 
-// 保存用デッキレシピ
+/**
+ * 保存用デッキレシピ
+ * 軽量なID+枚数形式でデータを保持
+ */
 export interface DeckRecipe extends DeckBase {
-  // カードIDのみ保持
-  mainDeck: DeckCardEntry[];
-  extraDeck: DeckCardEntry[];
+  mainDeck: RecipeCardEntry[];
+  extraDeck: RecipeCardEntry[];
 }
 
-// デッキレシピをロードして作成するデッキデータ
+/**
+ * ロード済みデッキデータ
+ * CardDataと枚数を保持し、統計情報も含む
+ * 同名カードの重複インスタンスを避けてメモリ効率化
+ */
 export interface DeckData extends DeckBase {
-  // CardData と枚数を保持（同名カードの重複インスタンスを避ける）
-  mainDeck: DeckCardData[];
-  extraDeck: DeckCardData[];
+  mainDeck: LoadedCardEntry[];
+  extraDeck: LoadedCardEntry[];
+  stats: DeckStats; // 統計情報を事前計算
 }

--- a/skeleton-app/src/lib/types/ygoprodeck.ts
+++ b/skeleton-app/src/lib/types/ygoprodeck.ts
@@ -1,4 +1,4 @@
-import type { Card, CardType } from "$lib/types/card";
+import type { Card, CardData, CardType } from "$lib/types/card";
 
 interface YGOProDeckCardImage {
   id: number;
@@ -41,18 +41,18 @@ export interface YGOProDeckCard {
   card_prices?: YGOProDeckCardPrice[];
 }
 
-export function convertYGOProDeckCardToCard(apiCard: YGOProDeckCard, quantity = 1): Card {
-  // カードタイプを正規化
-  const normalizeType = (type: string): CardType => {
-    const lowerType = type.toLowerCase();
-    if (lowerType.includes("monster")) return "monster";
-    if (lowerType.includes("spell")) return "spell";
-    if (lowerType.includes("trap")) return "trap";
+// カードタイプを正規化する内部関数
+function normalizeType(type: string): CardType {
+  const lowerType = type.toLowerCase();
+  if (lowerType.includes("monster")) return "monster";
+  if (lowerType.includes("spell")) return "spell";
+  if (lowerType.includes("trap")) return "trap";
 
-    // デフォルトはmonster（安全のため）
-    return "monster";
-  };
+  // デフォルトはmonster（安全のため）
+  return "monster";
+}
 
+export function convertYGOProDeckCardToCardData(apiCard: YGOProDeckCard): CardData {
   // 画像URL を取得（最初の画像を使用）
   const cardImage = apiCard.card_images[0];
 
@@ -86,11 +86,16 @@ export function convertYGOProDeckCardToCard(apiCard: YGOProDeckCard, quantity = 
           imageCropped: cardImage.image_url_cropped,
         }
       : undefined,
+  };
+}
 
+export function convertYGOProDeckCardToCard(apiCard: YGOProDeckCard, quantity = 1): Card {
+  const cardData = convertYGOProDeckCardToCardData(apiCard);
+
+  return {
+    ...cardData,
     // UI用プロパティ
-    ui: {
-      quantity,
-    },
+    quantity,
   };
 }
 

--- a/skeleton-app/src/lib/types/ygoprodeck.ts
+++ b/skeleton-app/src/lib/types/ygoprodeck.ts
@@ -89,13 +89,12 @@ export function convertYGOProDeckCardToCardData(apiCard: YGOProDeckCard): CardDa
   };
 }
 
-export function convertYGOProDeckCardToCard(apiCard: YGOProDeckCard, quantity = 1): Card {
+export function convertYGOProDeckCardToCard(apiCard: YGOProDeckCard): Card {
   const cardData = convertYGOProDeckCardToCardData(apiCard);
 
   return {
     ...cardData,
-    // UI用プロパティ
-    quantity,
+    // ゲーム状態プロパティは初期値なし（必要に応じて後で設定）
   };
 }
 

--- a/skeleton-app/src/lib/utils/deckLoader.ts
+++ b/skeleton-app/src/lib/utils/deckLoader.ts
@@ -1,24 +1,23 @@
 import { error } from "@sveltejs/kit";
-import type { Card } from "$lib/types/card";
-import type { DeckCardEntry, DeckData } from "$lib/types/deck";
-import { convertYGOProDeckCardToCard, type YGOProDeckCard } from "$lib/types/ygoprodeck";
+import type { DeckCardEntry, DeckCardData, DeckData } from "$lib/types/deck";
+import { convertYGOProDeckCardToCardData, type YGOProDeckCard } from "$lib/types/ygoprodeck";
 import { getCardsByIds } from "$lib/api/ygoprodeck";
 import { sampleDeckRecipes } from "$lib/data/sampleDeckRecipes";
 
-// デッキエントリーからCard配列を作成する内部関数
-function buildCardArray(ygoCardMap: Map<number, YGOProDeckCard>, entries: DeckCardEntry[]): Card[] {
-  const cards: Card[] = [];
+// デッキエントリーからDeckCardData配列を作成する内部関数
+function buildDeckCardDataArray(ygoCardMap: Map<number, YGOProDeckCard>, entries: DeckCardEntry[]): DeckCardData[] {
+  const deckCards: DeckCardData[] = [];
   for (const entry of entries) {
     const ygoCard = ygoCardMap.get(entry.id);
     if (ygoCard) {
-      const card = convertYGOProDeckCardToCard(ygoCard, entry.quantity);
-      // quantity分だけカードを追加
-      for (let i = 0; i < entry.quantity; i++) {
-        cards.push(card);
-      }
+      const cardData = convertYGOProDeckCardToCardData(ygoCard);
+      deckCards.push({
+        card: cardData,
+        quantity: entry.quantity,
+      });
     }
   }
-  return cards;
+  return deckCards;
 }
 
 /**
@@ -47,8 +46,8 @@ export async function loadDeckData(deckId: string, fetch: typeof window.fetch): 
   const ygoCardMap = new Map(ygoCards.map((card) => [card.id, card]));
 
   // メインデッキとエクストラデッキのカード配列を作成
-  const mainDeckCards = buildCardArray(ygoCardMap, recipe.mainDeck);
-  const extraDeckCards = buildCardArray(ygoCardMap, recipe.extraDeck);
+  const mainDeckCards = buildDeckCardDataArray(ygoCardMap, recipe.mainDeck);
+  const extraDeckCards = buildDeckCardDataArray(ygoCardMap, recipe.extraDeck);
 
   const deckData: DeckData = {
     name: recipe.name,

--- a/skeleton-app/src/lib/utils/deckLoader.ts
+++ b/skeleton-app/src/lib/utils/deckLoader.ts
@@ -15,7 +15,7 @@ function buildLoadedCardEntries(
     if (ygoCard) {
       const cardData = convertYGOProDeckCardToCardData(ygoCard);
       loadedCards.push({
-        card: cardData,
+        cardData: cardData,
         quantity: entry.quantity,
       });
     }
@@ -31,15 +31,15 @@ function calculateDeckStats(mainDeck: LoadedCardEntry[], extraDeck: LoadedCardEn
   const uniqueCards = allCards.length;
 
   const monsterCount = mainDeck
-    .filter((entry) => entry.card.type === "monster")
+    .filter((entry) => entry.cardData.type === "monster")
     .reduce((sum, entry) => sum + entry.quantity, 0);
 
   const spellCount = mainDeck
-    .filter((entry) => entry.card.type === "spell")
+    .filter((entry) => entry.cardData.type === "spell")
     .reduce((sum, entry) => sum + entry.quantity, 0);
 
   const trapCount = mainDeck
-    .filter((entry) => entry.card.type === "trap")
+    .filter((entry) => entry.cardData.type === "trap")
     .reduce((sum, entry) => sum + entry.quantity, 0);
 
   return {

--- a/skeleton-app/src/routes/(auth)/recipe/[deckId]/+page.svelte
+++ b/skeleton-app/src/routes/(auth)/recipe/[deckId]/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { navigateTo } from "$lib/utils/navigation";
   import Card from "$lib/components/atoms/Card.svelte";
-  import type { DeckCardData } from "$lib/types/deck";
+  import type { LoadedCardEntry } from "$lib/types/deck";
   import type { PageData } from "./$types";
 
   let { data }: { data: PageData } = $props();
@@ -11,16 +11,18 @@
     navigateTo(`/simulator/${data.deckId}`);
   }
 
-  // カードタイプ別にフィルタする関数（DeckCardData用）
-  function getCardsByType(cards: DeckCardData[], type: string) {
-    return cards.filter((cardData) => cardData.card.type === type);
+  // カードタイプ別にフィルタする関数（LoadedCardEntry用）
+  function getCardsByType(cards: LoadedCardEntry[], type: string) {
+    return cards.filter((cardEntry) => cardEntry.card.type === type);
   }
 
-  // カードタイプ別の統計情報
+  // カードタイプ別の統計情報（事前計算された統計を使用）
   const monsterCards = getCardsByType(selectedDeckData.mainDeck, "monster");
   const spellCards = getCardsByType(selectedDeckData.mainDeck, "spell");
   const trapCards = getCardsByType(selectedDeckData.mainDeck, "trap");
-  const totalCards = selectedDeckData.mainDeck.reduce((sum, cardData) => sum + cardData.quantity, 0);
+
+  // 統計情報は事前計算済み
+  const { totalCards, monsterCount, spellCount, trapCount } = selectedDeckData.stats;
 </script>
 
 <div class="container mx-auto p-4">
@@ -49,9 +51,7 @@
           <span class="w-4 h-4 bg-yellow-500 rounded mr-2"></span>
           モンスター
         </h3>
-        <span class="badge preset-tonal-surface text-sm"
-          >{monsterCards.reduce((sum, cardData) => sum + cardData.quantity, 0)}枚</span
-        >
+        <span class="badge preset-tonal-surface text-sm">{monsterCount}枚</span>
       </div>
       {#if monsterCards.length > 0}
         <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8 gap-4">
@@ -76,9 +76,7 @@
           <span class="w-4 h-4 bg-green-500 rounded mr-2"></span>
           魔法
         </h3>
-        <span class="badge preset-tonal-surface text-sm"
-          >{spellCards.reduce((sum, cardData) => sum + cardData.quantity, 0)}枚</span
-        >
+        <span class="badge preset-tonal-surface text-sm">{spellCount}枚</span>
       </div>
       {#if spellCards.length > 0}
         <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8 gap-4">
@@ -103,9 +101,7 @@
           <span class="w-4 h-4 bg-purple-500 rounded mr-2"></span>
           罠
         </h3>
-        <span class="badge preset-tonal-surface text-sm"
-          >{trapCards.reduce((sum, cardData) => sum + cardData.quantity, 0)}枚</span
-        >
+        <span class="badge preset-tonal-surface text-sm">{trapCount}枚</span>
       </div>
       {#if trapCards.length > 0}
         <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8 gap-4">

--- a/skeleton-app/src/routes/(auth)/recipe/[deckId]/+page.svelte
+++ b/skeleton-app/src/routes/(auth)/recipe/[deckId]/+page.svelte
@@ -13,7 +13,7 @@
 
   // カードタイプ別にフィルタする関数（LoadedCardEntry用）
   function getCardsByType(cards: LoadedCardEntry[], type: string) {
-    return cards.filter((cardEntry) => cardEntry.card.type === type);
+    return cards.filter((cardEntry) => cardEntry.cardData.type === type);
   }
 
   // カードタイプ別の統計情報（事前計算された統計を使用）
@@ -55,13 +55,13 @@
       </div>
       {#if monsterCards.length > 0}
         <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8 gap-4">
-          {#each monsterCards as cardData (cardData.card.id)}
+          {#each monsterCards as cardEntry (cardEntry.cardData.id)}
             <div class="relative">
-              <Card card={cardData.card} size="medium" showDetails={true} />
+              <Card card={cardEntry.cardData} size="medium" showDetails={true} />
               <div
                 class="absolute -top-2 bg-primary-500 text-white text-xs rounded-full w-6 h-6 flex items-center justify-center font-bold"
               >
-                {cardData.quantity}
+                {cardEntry.quantity}
               </div>
             </div>
           {/each}
@@ -80,13 +80,13 @@
       </div>
       {#if spellCards.length > 0}
         <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8 gap-4">
-          {#each spellCards as cardData (cardData.card.id)}
+          {#each spellCards as cardEntry (cardEntry.cardData.id)}
             <div class="relative">
-              <Card card={cardData.card} size="medium" showDetails={true} />
+              <Card card={cardEntry.cardData} size="medium" showDetails={true} />
               <div
                 class="absolute -top-2 bg-primary-500 text-white text-xs rounded-full w-6 h-6 flex items-center justify-center font-bold"
               >
-                {cardData.quantity}
+                {cardEntry.quantity}
               </div>
             </div>
           {/each}
@@ -105,13 +105,13 @@
       </div>
       {#if trapCards.length > 0}
         <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8 gap-4">
-          {#each trapCards as cardData (cardData.card.id)}
+          {#each trapCards as cardEntry (cardEntry.cardData.id)}
             <div class="relative">
-              <Card card={cardData.card} size="medium" showDetails={true} />
+              <Card card={cardEntry.cardData} size="medium" showDetails={true} />
               <div
                 class="absolute -top-2 bg-primary-500 text-white text-xs rounded-full w-6 h-6 flex items-center justify-center font-bold"
               >
-                {cardData.quantity}
+                {cardEntry.quantity}
               </div>
             </div>
           {/each}
@@ -133,8 +133,8 @@
     <section>
       {#if selectedDeckData.extraDeck.length > 0}
         <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8 gap-4">
-          {#each selectedDeckData.extraDeck as cardData (cardData.card.id)}
-            <Card card={cardData.card} size="medium" showDetails={true} />
+          {#each selectedDeckData.extraDeck as cardEntry (cardEntry.cardData.id)}
+            <Card card={cardEntry.cardData} size="medium" showDetails={true} />
           {/each}
         </div>
       {/if}

--- a/skeleton-app/src/routes/(auth)/recipe/[deckId]/+page.svelte
+++ b/skeleton-app/src/routes/(auth)/recipe/[deckId]/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { navigateTo } from "$lib/utils/navigation";
   import Card from "$lib/components/atoms/Card.svelte";
-  import type { Card as CardType } from "$lib/types/card";
+  import type { DeckCardData } from "$lib/types/deck";
   import type { PageData } from "./$types";
 
   let { data }: { data: PageData } = $props();
@@ -11,32 +11,16 @@
     navigateTo(`/simulator/${data.deckId}`);
   }
 
-  // カードタイプ別にフィルタする関数
-  function getCardsByType(cards: CardType[], type: string) {
-    return cards.filter((card) => card.type === type);
-  }
-
-  // カードの数量を計算する関数
-  function countCardQuantity(cards: CardType[], targetCard: CardType): number {
-    return cards.filter((card) => card.id === targetCard.id).length;
-  }
-
-  // 重複を除いたカードリストを作成する関数
-  function getUniqueCards(cards: CardType[]): CardType[] {
-    const uniqueMap = new Map<number, CardType>();
-    cards.forEach((card) => {
-      if (!uniqueMap.has(card.id)) {
-        uniqueMap.set(card.id, card);
-      }
-    });
-    return Array.from(uniqueMap.values());
+  // カードタイプ別にフィルタする関数（DeckCardData用）
+  function getCardsByType(cards: DeckCardData[], type: string) {
+    return cards.filter((cardData) => cardData.card.type === type);
   }
 
   // カードタイプ別の統計情報
-  const monsterCards = getUniqueCards(getCardsByType(selectedDeckData.mainDeck, "monster"));
-  const spellCards = getUniqueCards(getCardsByType(selectedDeckData.mainDeck, "spell"));
-  const trapCards = getUniqueCards(getCardsByType(selectedDeckData.mainDeck, "trap"));
-  const totalCards = selectedDeckData.mainDeck.length;
+  const monsterCards = getCardsByType(selectedDeckData.mainDeck, "monster");
+  const spellCards = getCardsByType(selectedDeckData.mainDeck, "spell");
+  const trapCards = getCardsByType(selectedDeckData.mainDeck, "trap");
+  const totalCards = selectedDeckData.mainDeck.reduce((sum, cardData) => sum + cardData.quantity, 0);
 </script>
 
 <div class="container mx-auto p-4">
@@ -66,18 +50,18 @@
           モンスター
         </h3>
         <span class="badge preset-tonal-surface text-sm"
-          >{getCardsByType(selectedDeckData.mainDeck, "monster").length}枚</span
+          >{monsterCards.reduce((sum, cardData) => sum + cardData.quantity, 0)}枚</span
         >
       </div>
       {#if monsterCards.length > 0}
         <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8 gap-4">
-          {#each monsterCards as card (card.id)}
+          {#each monsterCards as cardData (cardData.card.id)}
             <div class="relative">
-              <Card {card} size="medium" showDetails={true} />
+              <Card card={cardData.card} size="medium" showDetails={true} />
               <div
                 class="absolute -top-2 bg-primary-500 text-white text-xs rounded-full w-6 h-6 flex items-center justify-center font-bold"
               >
-                {countCardQuantity(selectedDeckData.mainDeck, card)}
+                {cardData.quantity}
               </div>
             </div>
           {/each}
@@ -93,18 +77,18 @@
           魔法
         </h3>
         <span class="badge preset-tonal-surface text-sm"
-          >{getCardsByType(selectedDeckData.mainDeck, "spell").length}枚</span
+          >{spellCards.reduce((sum, cardData) => sum + cardData.quantity, 0)}枚</span
         >
       </div>
       {#if spellCards.length > 0}
         <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8 gap-4">
-          {#each spellCards as card (card.id)}
+          {#each spellCards as cardData (cardData.card.id)}
             <div class="relative">
-              <Card {card} size="medium" showDetails={true} />
+              <Card card={cardData.card} size="medium" showDetails={true} />
               <div
                 class="absolute -top-2 bg-primary-500 text-white text-xs rounded-full w-6 h-6 flex items-center justify-center font-bold"
               >
-                {countCardQuantity(selectedDeckData.mainDeck, card)}
+                {cardData.quantity}
               </div>
             </div>
           {/each}
@@ -120,18 +104,18 @@
           罠
         </h3>
         <span class="badge preset-tonal-surface text-sm"
-          >{getCardsByType(selectedDeckData.mainDeck, "trap").length}枚</span
+          >{trapCards.reduce((sum, cardData) => sum + cardData.quantity, 0)}枚</span
         >
       </div>
       {#if trapCards.length > 0}
         <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8 gap-4">
-          {#each trapCards as card (card.id)}
+          {#each trapCards as cardData (cardData.card.id)}
             <div class="relative">
-              <Card {card} size="medium" showDetails={true} />
+              <Card card={cardData.card} size="medium" showDetails={true} />
               <div
                 class="absolute -top-2 bg-primary-500 text-white text-xs rounded-full w-6 h-6 flex items-center justify-center font-bold"
               >
-                {countCardQuantity(selectedDeckData.mainDeck, card)}
+                {cardData.quantity}
               </div>
             </div>
           {/each}
@@ -144,15 +128,17 @@
     <!-- エクストラデッキ -->
     <div class="mb-4 flex items-center space-x-4">
       <h2 class="h3">エクストラデッキ</h2>
-      <span class="badge preset-tonal-surface text-sm">{selectedDeckData.extraDeck.length}枚</span>
+      <span class="badge preset-tonal-surface text-sm"
+        >{selectedDeckData.extraDeck.reduce((sum, cardData) => sum + cardData.quantity, 0)}枚</span
+      >
     </div>
 
     <!-- TODO: シンクロ・エクシーズなどを分類する -->
     <section>
       {#if selectedDeckData.extraDeck.length > 0}
         <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8 gap-4">
-          {#each selectedDeckData.extraDeck as card (card.id)}
-            <Card {card} size="medium" showDetails={true} />
+          {#each selectedDeckData.extraDeck as cardData (cardData.card.id)}
+            <Card card={cardData.card} size="medium" showDetails={true} />
           {/each}
         </div>
       {/if}


### PR DESCRIPTION
## Summary
- DeckData.mainDeck/extraDeckをDeckCardData[]に変更し、CardDataと枚数(quantity)を分離管理
- 同名カードの重複インスタンス作成を避けてメモリ効率を向上
- デッキレシピ閲覧画面の不要なユーティリティ関数（countCardQuantity、getUniqueCards）を削除

## 主な変更点
- **新しいDeckCardData型**: CardDataと枚数を組み合わせた構造
- **deckLoader最適化**: buildDeckCardDataArrayでDeckCardData形式にデータ構築
- **DuelState対応**: DeckCardDataからCard配列への展開処理を追加
- **UI最適化**: デッキレシピ閲覧画面のコード簡略化

## Test plan
- [x] 型チェック実行（npm run check）
- [x] リンター実行（npm run lint）
- [x] テストファイルを新しい型システムに対応

🤖 Generated with [Claude Code](https://claude.ai/code)