### PR TITLE
feat: カードタイプ別の事前分類によるデッキデータ構造最適化

### DIFF
--- a/skeleton-app/src/lib/classes/DuelState.ts
+++ b/skeleton-app/src/lib/classes/DuelState.ts
@@ -1,6 +1,6 @@
 import type { Card } from "$lib/types/card";
 import type { DuelStateData, DuelStats } from "$lib/types/duel";
-import type { DeckData, LoadedCardEntry } from "$lib/types/deck";
+import type { DeckData, LoadedCardEntry, MainDeckData } from "$lib/types/deck";
 
 /**
  * ゲーム状態管理クラス
@@ -62,12 +62,26 @@ export class DuelState {
   }
 
   /**
+   * MainDeckDataをCard配列に展開するヘルパー関数
+   */
+  private static expandMainDeckData(mainDeckData: MainDeckData): Card[] {
+    const allCards: Card[] = [];
+
+    // 各カードタイプの配列を結合
+    allCards.push(...this.expandLoadedCardEntries(mainDeckData.monsters));
+    allCards.push(...this.expandLoadedCardEntries(mainDeckData.spells));
+    allCards.push(...this.expandLoadedCardEntries(mainDeckData.traps));
+
+    return allCards;
+  }
+
+  /**
    * デッキレシピをロードしてインスタンスを作成
    */
   static loadDeck(deckData: DeckData, name?: string): DuelState {
     return new DuelState({
       name: name || deckData.name,
-      mainDeck: this.expandLoadedCardEntries(deckData.mainDeck),
+      mainDeck: this.expandMainDeckData(deckData.mainDeck),
       extraDeck: this.expandLoadedCardEntries(deckData.extraDeck),
       sourceRecipe: deckData.name,
     });

--- a/skeleton-app/src/lib/classes/__tests__/DuelState.test.ts
+++ b/skeleton-app/src/lib/classes/__tests__/DuelState.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { DuelState } from "../DuelState";
 import type { CardData } from "$lib/types/card";
-import type { DeckData, LoadedCardEntry } from "$lib/types/deck";
+import type { DeckData, LoadedCardEntry, MainDeckData } from "$lib/types/deck";
 
 describe("DuelState", () => {
   let duelState: DuelState;
@@ -46,24 +46,44 @@ describe("DuelState", () => {
       description: "テスト用の魔法カード",
     };
 
-    // サンプルレシピを作成（LoadedCardEntry形式）
-    const mainDeck: LoadedCardEntry[] = Array(40)
+    // サンプルレシピを作成（新しい構造対応）
+    const monsters: LoadedCardEntry[] = Array(30)
       .fill(null)
       .map((_, i) => ({
-        cardData: { ...sampleCardData, id: 5000 + i, name: `カード${i}` },
+        cardData: { ...sampleCardData, id: 5000 + i, name: `モンスター${i}` },
         quantity: 1,
       }));
 
+    const spells: LoadedCardEntry[] = Array(8)
+      .fill(null)
+      .map((_, i) => ({
+        cardData: { ...spellCardData, id: 6000 + i, name: `魔法${i}` },
+        quantity: 1,
+      }));
+
+    const traps: LoadedCardEntry[] = Array(2)
+      .fill(null)
+      .map((_, i) => ({
+        cardData: { ...spellCardData, id: 7000 + i, name: `罠${i}`, type: "trap" as const },
+        quantity: 1,
+      }));
+
+    const mainDeckData: MainDeckData = {
+      monsters,
+      spells,
+      traps,
+    };
+
     deckData = {
       name: "テストデッキ",
-      mainDeck,
+      mainDeck: mainDeckData,
       extraDeck: [],
       stats: {
         totalCards: 40,
         uniqueCards: 40,
-        monsterCount: 40,
-        spellCount: 0,
-        trapCount: 0,
+        monsterCount: 30,
+        spellCount: 8,
+        trapCount: 2,
       },
     };
 

--- a/skeleton-app/src/lib/types/deck.ts
+++ b/skeleton-app/src/lib/types/deck.ts
@@ -46,12 +46,21 @@ export interface DeckRecipe extends DeckBase {
 }
 
 /**
+ * メインデッキの構造（カードタイプ別に事前分類）
+ */
+export interface MainDeckData {
+  monsters: LoadedCardEntry[]; // モンスターカード
+  spells: LoadedCardEntry[]; // 魔法カード
+  traps: LoadedCardEntry[]; // 罠カード
+}
+
+/**
  * ロード済みデッキデータ
- * CardDataと枚数を保持し、統計情報も含む
- * 同名カードの重複インスタンスを避けてメモリ効率化
+ * CardDataと枚数を保持し、カードタイプ別に事前分類済み
+ * フィルタリング処理を不要にしてパフォーマンス向上
  */
 export interface DeckData extends DeckBase {
-  mainDeck: LoadedCardEntry[];
-  extraDeck: LoadedCardEntry[];
+  mainDeck: MainDeckData; // カードタイプ別に分類済み
+  extraDeck: LoadedCardEntry[]; // エクストラデッキ（分類不要）
   stats: DeckStats; // 統計情報を事前計算
 }

--- a/skeleton-app/src/routes/(auth)/recipe/[deckId]/+page.svelte
+++ b/skeleton-app/src/routes/(auth)/recipe/[deckId]/+page.svelte
@@ -1,28 +1,18 @@
 <script lang="ts">
   import { navigateTo } from "$lib/utils/navigation";
   import Card from "$lib/components/atoms/Card.svelte";
-  import type { LoadedCardEntry } from "$lib/types/deck";
   import type { PageData } from "./$types";
 
   let { data }: { data: PageData } = $props();
   const selectedDeckData = data.deckData;
+  const { totalCards, monsterCount, spellCount, trapCount } = selectedDeckData.stats;
 
   function navigateToSimulator() {
     navigateTo(`/simulator/${data.deckId}`);
   }
 
-  // カードタイプ別にフィルタする関数（LoadedCardEntry用）
-  function getCardsByType(cards: LoadedCardEntry[], type: string) {
-    return cards.filter((cardEntry) => cardEntry.cardData.type === type);
-  }
-
-  // カードタイプ別の統計情報（事前計算された統計を使用）
-  const monsterCards = getCardsByType(selectedDeckData.mainDeck, "monster");
-  const spellCards = getCardsByType(selectedDeckData.mainDeck, "spell");
-  const trapCards = getCardsByType(selectedDeckData.mainDeck, "trap");
-
-  // 統計情報は事前計算済み
-  const { totalCards, monsterCount, spellCount, trapCount } = selectedDeckData.stats;
+  // カードタイプ別のデータに直接アクセス（フィルタリング不要）
+  const { monsters, spells, traps } = selectedDeckData.mainDeck;
 </script>
 
 <div class="container mx-auto p-4">
@@ -53,9 +43,9 @@
         </h3>
         <span class="badge preset-tonal-surface text-sm">{monsterCount}枚</span>
       </div>
-      {#if monsterCards.length > 0}
+      {#if monsters.length > 0}
         <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8 gap-4">
-          {#each monsterCards as cardEntry (cardEntry.cardData.id)}
+          {#each monsters as cardEntry (cardEntry.cardData.id)}
             <div class="relative">
               <Card card={cardEntry.cardData} size="medium" showDetails={true} />
               <div
@@ -78,9 +68,9 @@
         </h3>
         <span class="badge preset-tonal-surface text-sm">{spellCount}枚</span>
       </div>
-      {#if spellCards.length > 0}
+      {#if spells.length > 0}
         <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8 gap-4">
-          {#each spellCards as cardEntry (cardEntry.cardData.id)}
+          {#each spells as cardEntry (cardEntry.cardData.id)}
             <div class="relative">
               <Card card={cardEntry.cardData} size="medium" showDetails={true} />
               <div
@@ -103,9 +93,9 @@
         </h3>
         <span class="badge preset-tonal-surface text-sm">{trapCount}枚</span>
       </div>
-      {#if trapCards.length > 0}
+      {#if traps.length > 0}
         <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8 gap-4">
-          {#each trapCards as cardEntry (cardEntry.cardData.id)}
+          {#each traps as cardEntry (cardEntry.cardData.id)}
             <div class="relative">
               <Card card={cardEntry.cardData} size="medium" showDetails={true} />
               <div


### PR DESCRIPTION
## Summary
- MainDeckDataインターフェースを追加してメインデッキをモンスター/魔法/罠に事前分類
- deckLoaderでロード時にカードタイプ別に分類して冗長なランタイムフィルタリングを排除
- UIコンポーネントでgetCardsByType関数を削除し直接アクセスに変更してパフォーマンス向上
- DuelStateクラスにMainDeckData展開機能を追加
- テストファイルを新しいデータ構造に対応

## Test plan
- [x] 型チェック (npm run check) - エラーなし
- [x] リンター (npm run lint) - エラーなし  
- [x] 既存テストが新しい構造で正常動作することを確認
- [x] UIでカード表示が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)