### PR TITLE
feat: 墓地専用Graveyardコンポーネントを追加

### DIFF
--- a/skeleton-app/src/lib/components/atoms/Card.svelte
+++ b/skeleton-app/src/lib/components/atoms/Card.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
   import type { Card } from "$lib/types/card";
+  import { CARD_SIZE_CLASSES, type ComponentSize } from "$lib/constants/sizes";
   import cardBackImage from "$lib/assets/CardBack.jpg";
 
   interface CardComponentProps {
     card?: Card;
-    size?: "small" | "medium" | "large";
+    size?: ComponentSize;
     showDetails?: boolean;
     clickable?: boolean;
     selectable?: boolean;
@@ -32,13 +33,6 @@
 
   let isHovered = $state(false);
   let isSelected = $state(card?.isSelected || false);
-
-  // サイズクラスの定義
-  const sizeClasses = {
-    small: "w-16 h-24",
-    medium: "w-22 h-32",
-    large: "w-32 h-48",
-  };
 
   // カードクリック処理
   function handleClick() {
@@ -102,7 +96,7 @@
   // 共通クラス
   const commonClasses = $derived(() => {
     return `
-      ${sizeClasses[size]}
+      ${CARD_SIZE_CLASSES[size]}
       ${animationClasses}
       ${hoverClasses}
       ${selectedClasses}

--- a/skeleton-app/src/lib/components/atoms/CountBadge.svelte
+++ b/skeleton-app/src/lib/components/atoms/CountBadge.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  interface CountBadgeProps {
+    count: number;
+    size?: "small" | "medium" | "large";
+    colorClasses?: string;
+  }
+
+  let { count, size = "medium", colorClasses = "bg-primary-200 text-primary-900" }: CountBadgeProps = $props();
+
+  // サイズ別のクラス
+  const sizeClasses = {
+    small: "w-4 h-4 text-xs",
+    medium: "w-6 h-6 text-xs",
+    large: "w-8 h-8 text-sm",
+  };
+</script>
+
+<div
+  class="absolute -top-2 -right-2 {sizeClasses[
+    size
+  ]} {colorClasses} rounded-full flex items-center justify-center font-bold shadow-md z-10"
+>
+  {count}
+</div>

--- a/skeleton-app/src/lib/components/atoms/CountBadge.svelte
+++ b/skeleton-app/src/lib/components/atoms/CountBadge.svelte
@@ -1,22 +1,17 @@
 <script lang="ts">
+  import { BADGE_SIZE_CLASSES, type ComponentSize } from "$lib/constants/sizes";
+
   interface CountBadgeProps {
     count: number;
-    size?: "small" | "medium" | "large";
+    size?: ComponentSize;
     colorClasses?: string;
   }
 
   let { count, size = "medium", colorClasses = "bg-primary-200 text-primary-900" }: CountBadgeProps = $props();
-
-  // サイズ別のクラス
-  const sizeClasses = {
-    small: "w-4 h-4 text-xs",
-    medium: "w-6 h-6 text-xs",
-    large: "w-8 h-8 text-sm",
-  };
 </script>
 
 <div
-  class="absolute -top-2 -right-2 {sizeClasses[
+  class="absolute -top-2 -right-2 {BADGE_SIZE_CLASSES[
     size
   ]} {colorClasses} rounded-full flex items-center justify-center font-bold shadow-md z-10"
 >

--- a/skeleton-app/src/lib/components/organisms/DuelField.svelte
+++ b/skeleton-app/src/lib/components/organisms/DuelField.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import Card from "$lib/components/atoms/Card.svelte";
+  import Graveyard from "$lib/components/organisms/Graveyard.svelte";
   import type { Card as CardType } from "$lib/types/card";
 
   // ゾーン数の定数
@@ -9,7 +10,7 @@
   interface DuelFieldProps {
     deckCards?: number;
     extraDeckCards?: number;
-    graveyardCards?: number;
+    graveyardCards?: CardType[];
     fieldCards?: CardType[];
     monsterCards?: CardType[];
     spellTrapCards?: CardType[];
@@ -18,7 +19,7 @@
   let {
     deckCards = 40,
     extraDeckCards = 15,
-    graveyardCards = 0,
+    graveyardCards = [],
     fieldCards = [],
     monsterCards = [],
     spellTrapCards = [],
@@ -80,18 +81,11 @@
 
       <!-- 墓地 -->
       <div class="flex justify-center">
-        <div class="relative">
-          <!-- プレースホルダー色調：グレー -->
-          <div style="filter: grayscale(0.8) brightness(0.7) contrast(1.2);">
-            <Card
-              placeholder={true}
-              placeholderText="墓地\n{graveyardCards}枚"
-              size="medium"
-              clickable={true}
-              onClick={handleGraveyardClick}
-            />
-          </div>
-        </div>
+        <Graveyard 
+          cards={graveyardCards}
+          size="medium"
+          onClick={handleGraveyardClick}
+        />
       </div>
     </div>
 

--- a/skeleton-app/src/lib/components/organisms/Graveyard.svelte
+++ b/skeleton-app/src/lib/components/organisms/Graveyard.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import CardComponent from "$lib/components/atoms/Card.svelte";
+  import CountBadge from "$lib/components/atoms/CountBadge.svelte";
   import type { Card } from "$lib/types/card";
   import cardBackImage from "$lib/assets/CardBack.jpg";
 
@@ -64,11 +65,7 @@
     <div class="absolute inset-1">
       <CardComponent card={topCard} {size} clickable={false} />
     </div>
-    <div
-      class="absolute -top-2 -right-2 bg-gray-600 text-white text-xs rounded-full w-6 h-6 flex items-center justify-center font-bold shadow-md z-10"
-    >
-      {cards.length}
-    </div>
+    <CountBadge count={cards.length} />
   {:else}
     <!-- カードが無い場合、プレースホルダー色調：グレーを表示する -->
     <div
@@ -76,11 +73,7 @@
       style="filter: grayscale(0.8) brightness(0.7) contrast(1.2);"
     >
       <img src={cardBackImage} alt="墓地" class="w-full h-full object-cover opacity-30 rounded-sm" />
-      <div
-        class="absolute -top-2 -right-2 bg-gray-600 text-white text-xs rounded-full w-6 h-6 flex items-center justify-center font-bold shadow-md z-10"
-      >
-        {cards.length}
-      </div>
     </div>
+    <CountBadge count={cards.length} />
   {/if}
 </div>

--- a/skeleton-app/src/lib/components/organisms/Graveyard.svelte
+++ b/skeleton-app/src/lib/components/organisms/Graveyard.svelte
@@ -2,11 +2,12 @@
   import CardComponent from "$lib/components/atoms/Card.svelte";
   import CountBadge from "$lib/components/atoms/CountBadge.svelte";
   import type { Card } from "$lib/types/card";
+  import { CARD_SIZE_CLASSES, type ComponentSize } from "$lib/constants/sizes";
   import cardBackImage from "$lib/assets/CardBack.jpg";
 
   interface GraveyardProps {
     cards: Card[];
-    size?: "small" | "medium" | "large";
+    size?: ComponentSize;
     onClick?: () => void;
   }
 
@@ -14,13 +15,6 @@
 
   // 最後に墓地に置かれたカード
   const topCard = $derived(cards.length > 0 ? cards[cards.length - 1] : null);
-
-  // サイズクラスの定義
-  const sizeClasses = {
-    small: "w-16 h-24",
-    medium: "w-22 h-32",
-    large: "w-32 h-48",
-  };
 
   // クリック処理
   function handleClick() {
@@ -43,7 +37,7 @@
 
 <div
   class="
-    {sizeClasses[size]}
+    {CARD_SIZE_CLASSES[size]}
     relative
     border-2 border-dashed border-gray-400
     rounded-lg

--- a/skeleton-app/src/lib/components/organisms/Graveyard.svelte
+++ b/skeleton-app/src/lib/components/organisms/Graveyard.svelte
@@ -11,7 +11,7 @@
 
   let { cards, size = "medium", onClick }: GraveyardProps = $props();
 
-  // 最上位カード（最後に追加されたカード）
+  // 最後に墓地に置かれたカード
   const topCard = $derived(cards.length > 0 ? cards[cards.length - 1] : null);
 
   // サイズクラスの定義
@@ -57,28 +57,30 @@
   onclick={handleClick}
   onmouseenter={handleMouseEnter}
   onmouseleave={handleMouseLeave}
-  onkeydown={(e) => e.key === 'Enter' && handleClick()}
+  onkeydown={(e) => e.key === "Enter" && handleClick()}
 >
   {#if topCard}
-    <!-- 最上位カードがある場合 -->
+    <!-- カードがある場合、最後に置かれたカードを表示 -->
     <div class="absolute inset-1">
       <CardComponent card={topCard} {size} clickable={false} />
     </div>
-
-    <!-- 枚数表示（右上） -->
     <div
       class="absolute -top-2 -right-2 bg-gray-600 text-white text-xs rounded-full w-6 h-6 flex items-center justify-center font-bold shadow-md z-10"
     >
       {cards.length}
     </div>
   {:else}
-    <!-- 墓地が空の場合のプレースホルダー -->
-    <div class="h-full flex flex-col items-center justify-center p-2">
-      <img src={cardBackImage} alt="墓地" class="w-8 h-12 object-cover opacity-30 mb-1" />
-      <span class="text-xs text-gray-600 dark:text-gray-400 font-medium text-center">
-        墓地<br />
-        {cards.length}枚
-      </span>
+    <!-- カードが無い場合、プレースホルダー色調：グレーを表示する -->
+    <div
+      class="h-full flex items-center justify-center p-1 relative"
+      style="filter: grayscale(0.8) brightness(0.7) contrast(1.2);"
+    >
+      <img src={cardBackImage} alt="墓地" class="w-full h-full object-cover opacity-30 rounded-sm" />
+      <div
+        class="absolute -top-2 -right-2 bg-gray-600 text-white text-xs rounded-full w-6 h-6 flex items-center justify-center font-bold shadow-md z-10"
+      >
+        {cards.length}
+      </div>
     </div>
   {/if}
 </div>

--- a/skeleton-app/src/lib/components/organisms/Graveyard.svelte
+++ b/skeleton-app/src/lib/components/organisms/Graveyard.svelte
@@ -1,0 +1,84 @@
+<script lang="ts">
+  import CardComponent from "$lib/components/atoms/Card.svelte";
+  import type { Card } from "$lib/types/card";
+  import cardBackImage from "$lib/assets/CardBack.jpg";
+
+  interface GraveyardProps {
+    cards: Card[];
+    size?: "small" | "medium" | "large";
+    onClick?: () => void;
+  }
+
+  let { cards, size = "medium", onClick }: GraveyardProps = $props();
+
+  // 最上位カード（最後に追加されたカード）
+  const topCard = $derived(cards.length > 0 ? cards[cards.length - 1] : null);
+
+  // サイズクラスの定義
+  const sizeClasses = {
+    small: "w-16 h-24",
+    medium: "w-22 h-32",
+    large: "w-32 h-48",
+  };
+
+  // クリック処理
+  function handleClick() {
+    if (onClick) {
+      onClick();
+    }
+  }
+
+  // ホバー状態
+  let isHovered = $state(false);
+
+  function handleMouseEnter() {
+    isHovered = true;
+  }
+
+  function handleMouseLeave() {
+    isHovered = false;
+  }
+</script>
+
+<div
+  class="
+    {sizeClasses[size]}
+    relative
+    border-2 border-dashed border-gray-400
+    rounded-lg
+    bg-gray-100 dark:bg-gray-800
+    transition-all duration-300
+    cursor-pointer
+    hover:border-gray-600 hover:bg-gray-200 dark:hover:bg-gray-700
+    {isHovered ? 'scale-105 shadow-lg' : ''}
+  "
+  role="button"
+  tabindex="0"
+  onclick={handleClick}
+  onmouseenter={handleMouseEnter}
+  onmouseleave={handleMouseLeave}
+  onkeydown={(e) => e.key === 'Enter' && handleClick()}
+>
+  {#if topCard}
+    <!-- 最上位カードがある場合 -->
+    <div class="absolute inset-1">
+      <CardComponent card={topCard} {size} clickable={false} />
+    </div>
+
+    <!-- 枚数表示（右上） -->
+    <div
+      class="absolute -top-2 -right-2 bg-gray-600 text-white text-xs rounded-full w-6 h-6 flex items-center justify-center font-bold shadow-md z-10"
+    >
+      {cards.length}
+    </div>
+  {:else}
+    <!-- 墓地が空の場合のプレースホルダー -->
+    <div class="h-full flex flex-col items-center justify-center p-2">
+      <img src={cardBackImage} alt="墓地" class="w-8 h-12 object-cover opacity-30 mb-1" />
+      <span class="text-xs text-gray-600 dark:text-gray-400 font-medium text-center">
+        墓地<br />
+        {cards.length}枚
+      </span>
+    </div>
+  {/if}
+</div>

--- a/skeleton-app/src/lib/constants/sizes.ts
+++ b/skeleton-app/src/lib/constants/sizes.ts
@@ -1,0 +1,25 @@
+/**
+ * コンポーネント共通のサイズ定義
+ */
+
+export type ComponentSize = "small" | "medium" | "large";
+
+/**
+ * カードコンポーネント用のサイズクラス
+ * Card、Graveyard等のカード関連コンポーネントで使用
+ */
+export const CARD_SIZE_CLASSES: Record<ComponentSize, string> = {
+  small: "w-16 h-24",
+  medium: "w-22 h-32",
+  large: "w-32 h-48",
+};
+
+/**
+ * バッジコンポーネント用のサイズクラス
+ * CountBadge等の小さなUIコンポーネントで使用
+ */
+export const BADGE_SIZE_CLASSES: Record<ComponentSize, string> = {
+  small: "w-4 h-4 text-xs",
+  medium: "w-6 h-6 text-xs",
+  large: "w-8 h-8 text-sm",
+};

--- a/skeleton-app/src/routes/(auth)/simulator/[deckId]/+page.svelte
+++ b/skeleton-app/src/routes/(auth)/simulator/[deckId]/+page.svelte
@@ -17,7 +17,7 @@
         <DuelField
           deckCards={duelStats.mainDeckRemaining}
           extraDeckCards={duelStats.extraDeckRemaining}
-          graveyardCards={duelStats.graveyardSize}
+          graveyardCards={duelState.graveyard}
         />
         <Hands cards={duelState.hands} />
       </div>


### PR DESCRIPTION
## 概要
issue #22 に対応して、墓地専用のGraveyardコンポーネントを作成し、DuelFieldでCardコンポーネントのプレースホルダーから差し替えました。

## 変更内容

### 🆕 新規作成: Graveyardコンポーネント
- **ファイル**: `src/lib/components/organisms/Graveyard.svelte`
- **機能**:
  - 墓地カード枚数の表示
  - 最上位カード表示（墓地にカードがある場合）
  - クリック・ホバーイベントハンドリング
  - レスポンシブサイズ対応（small/medium/large）
  - キーボードアクセシビリティ対応（Enter キー）
  - グレー系の色調でデザイン

### 🔄 修正: DuelField.svelte
- Graveyardコンポーネントをインポート
- `graveyardCards`プロパティを`number`から`Card[]`型に変更
- 81-95行目のCardプレースホルダーをGraveyardコンポーネントに置換

### 🔄 修正: シミュレーターページ
- DuelFieldに渡すデータを`duelStats.graveyardSize`から`duelState.graveyard`に変更
- 実際の墓地カード配列を連携

## テスト

### ✅ 動作確認済み
- TypeScriptエラーなし（`npm run check`）
- 墓地が空の場合のプレースホルダー表示
- 墓地にカードがある場合の最上位カード表示
- 枚数表示の正確性
- ホバー・クリックイベントの動作

### 📱 対応環境
- デスクトップ・モバイル対応
- ダークモード対応
- 各種スクリーンサイズ対応

## 受け入れ基準

- [x] 墓地の枚数が正しく表示される
- [x] 墓地にカードがある場合、最上位のカードが表示される  
- [x] 墓地にカードがない場合、適切なプレースホルダーが表示される
- [x] クリック時に適切なイベントが発火する
- [x] 既存のCardコンポーネントと同様のサイズ・レイアウトを維持
- [x] TypeScriptエラーがない

## 関連

- Closes #22
- 墓地機能の専用コンポーネント化によるコードの保守性向上
- 将来的な墓地操作機能の拡張に対応

🤖 Generated with [Claude Code](https://claude.ai/code)