### PR TITLE
refactor: Effect.executeをPromise<EffectResult>に統一

### DIFF
--- a/skeleton-app/src/lib/classes/effects/__tests__/BaseEffect.test.ts
+++ b/skeleton-app/src/lib/classes/effects/__tests__/BaseEffect.test.ts
@@ -16,7 +16,7 @@ class TestEffect extends BaseEffect {
     return this.shouldSucceed;
   }
 
-  execute(state: DuelState): EffectResult {
+  async execute(state: DuelState): Promise<EffectResult> {
     if (!this.shouldSucceed) {
       return this.createErrorResult("テスト用の失敗");
     }
@@ -55,8 +55,8 @@ describe("BaseEffect", () => {
   });
 
   describe("効果実行", () => {
-    it("成功時に正しい結果を返す", () => {
-      const result = testEffect.execute(duelState);
+    it("成功時に正しい結果を返す", async () => {
+      const result = await testEffect.execute(duelState);
 
       expect(result.success).toBe(true);
       expect(result.message).toBe("テスト効果が成功しました");
@@ -66,9 +66,9 @@ describe("BaseEffect", () => {
       expect(duelState.hands[0].name).toBe("テストカード");
     });
 
-    it("失敗時に正しい結果を返す", () => {
+    it("失敗時に正しい結果を返す", async () => {
       const failEffect = new TestEffect(false);
-      const result = failEffect.execute(duelState);
+      const result = await failEffect.execute(duelState);
 
       expect(result.success).toBe(false);
       expect(result.message).toBe("テスト用の失敗");

--- a/skeleton-app/src/lib/classes/effects/__tests__/EffectRepository.test.ts
+++ b/skeleton-app/src/lib/classes/effects/__tests__/EffectRepository.test.ts
@@ -13,7 +13,7 @@ class TestEffect extends BaseEffect {
     return true;
   }
 
-  execute(): EffectResult {
+  async execute(): Promise<EffectResult> {
     return this.createSuccessResult("テスト効果が実行されました");
   }
 }
@@ -27,7 +27,7 @@ class SecondTestEffect extends BaseEffect {
     return true;
   }
 
-  execute(): EffectResult {
+  async execute(): Promise<EffectResult> {
     return this.createSuccessResult("セカンド効果が実行されました");
   }
 }

--- a/skeleton-app/src/lib/classes/effects/__tests__/integration.test.ts
+++ b/skeleton-app/src/lib/classes/effects/__tests__/integration.test.ts
@@ -19,7 +19,9 @@ describe("Effects Integration", () => {
         { id: 4, name: "カード4", type: "monster", description: "テスト4" },
         { id: 5, name: "カード5", type: "spell", description: "テスト5" },
       ],
-      hands: [],
+      hands: [
+        { id: 55144522, name: "強欲な壺", type: "spell", description: "デッキから2枚ドローする" },
+      ],
     });
     duelState.currentPhase = "メインフェイズ1";
     duelState.gameResult = "ongoing";
@@ -214,23 +216,23 @@ describe("Effects Integration", () => {
       expect(effects[0].name).toBe("強欲な壺");
     });
 
-    it("DuelStateから強欲な壺の効果を実行できる", () => {
+    it("DuelStateから強欲な壺の効果を実行できる", async () => {
       const initialHandSize = duelState.hands.length;
-      const result = duelState.executeCardEffect(55144522);
+      const result = await duelState.executeCardEffect(55144522);
 
       expect(result.success).toBe(true);
       expect(result.message).toBe("2枚ドローしました");
-      expect(duelState.hands.length).toBe(initialHandSize + 2);
+      expect(duelState.hands.length).toBe(initialHandSize + 1); // 強欲な壺が墓地に送られ、2枚ドローされるので +2-1=+1
     });
 
-    it("存在しないカードの効果実行は失敗する", () => {
-      const result = duelState.executeCardEffect(99999);
+    it("存在しないカードの効果実行は失敗する", async () => {
+      const result = await duelState.executeCardEffect(99999);
 
       expect(result.success).toBe(false);
       expect(result.message).toBe("このカードには効果がありません");
     });
 
-    it("フルワークフロー: 登録→取得→実行", () => {
+    it("フルワークフロー: 登録→取得→実行", async () => {
       // 1. 効果が登録されていることを確認
       expect(EffectRepository.hasEffects(55144522)).toBe(true);
 
@@ -242,10 +244,10 @@ describe("Effects Integration", () => {
       const initialHandSize = duelState.hands.length;
       const initialDeckSize = duelState.mainDeck.length;
 
-      const result = duelState.executeEffect(effects[0]);
+      const result = await duelState.executeEffect(effects[0]);
 
       expect(result.success).toBe(true);
-      expect(duelState.hands.length).toBe(initialHandSize + 2);
+      expect(duelState.hands.length).toBe(initialHandSize + 1); // 強欲な壺が墓地に送られ、2枚ドローされるので +2-1=+1
       expect(duelState.mainDeck.length).toBe(initialDeckSize - 2);
     });
   });

--- a/skeleton-app/src/lib/classes/effects/__tests__/integration.test.ts
+++ b/skeleton-app/src/lib/classes/effects/__tests__/integration.test.ts
@@ -19,9 +19,7 @@ describe("Effects Integration", () => {
         { id: 4, name: "カード4", type: "monster", description: "テスト4" },
         { id: 5, name: "カード5", type: "spell", description: "テスト5" },
       ],
-      hands: [
-        { id: 55144522, name: "強欲な壺", type: "spell", description: "デッキから2枚ドローする" },
-      ],
+      hands: [{ id: 55144522, name: "強欲な壺", type: "spell", description: "デッキから2枚ドローする" }],
     });
     duelState.currentPhase = "メインフェイズ1";
     duelState.gameResult = "ongoing";

--- a/skeleton-app/src/lib/classes/effects/bases/BaseEffect.ts
+++ b/skeleton-app/src/lib/classes/effects/bases/BaseEffect.ts
@@ -29,7 +29,7 @@ export abstract class BaseEffect implements Effect {
    * 効果を実行する
    * 継承先でオーバーライドして具体的な効果処理を実装
    */
-  abstract execute(state: DuelState): EffectResult | Promise<EffectResult>;
+  abstract execute(state: DuelState): Promise<EffectResult>;
 
   /**
    * 効果実行前の共通処理

--- a/skeleton-app/src/lib/classes/effects/bases/BaseMagicEffect.ts
+++ b/skeleton-app/src/lib/classes/effects/bases/BaseMagicEffect.ts
@@ -159,7 +159,7 @@ export abstract class BaseMagicEffect extends BaseEffect {
   /**
    * 魔法効果の解決（サブクラスで実装）
    */
-  protected abstract resolveMagicEffect(state: DuelState): EffectResult | Promise<EffectResult>;
+  protected abstract resolveMagicEffect(state: DuelState): Promise<EffectResult>;
 
   /**
    * インタラクティブな効果かどうかを判定

--- a/skeleton-app/src/lib/classes/effects/cards/__tests__/GracefulCharityEffect.test.ts
+++ b/skeleton-app/src/lib/classes/effects/cards/__tests__/GracefulCharityEffect.test.ts
@@ -18,7 +18,12 @@ describe("GracefulCharityEffect", () => {
         { id: 6, name: "カード6", type: "monster", description: "テストカード6" },
       ],
       hands: [
-        { id: 79571449, name: "天使の施し", type: "spell", description: "デッキから3枚ドローし、その後手札から2枚捨てる" },
+        {
+          id: 79571449,
+          name: "天使の施し",
+          type: "spell",
+          description: "デッキから3枚ドローし、その後手札から2枚捨てる",
+        },
         { id: 10, name: "手札1", type: "monster", description: "手札のカード1" },
         { id: 11, name: "手札2", type: "spell", description: "手札のカード2" },
       ],
@@ -70,15 +75,27 @@ describe("GracefulCharityEffect", () => {
     });
 
     it("手札0枚でもドロー後に2枚捨てられるため発動可能", () => {
-      duelState.hands = [{ id: 79571449, name: "天使の施し", type: "spell", description: "デッキから3枚ドローし、その後手札から2枚捨てる" }]; // 天使の施しのみ
+      duelState.hands = [
+        {
+          id: 79571449,
+          name: "天使の施し",
+          type: "spell",
+          description: "デッキから3枚ドローし、その後手札から2枚捨てる",
+        },
+      ]; // 天使の施しのみ
       // 1 + 3 = 4枚 → 2枚捨てる可能
       expect(gracefulCharityEffect.canActivate(duelState)).toBe(true);
     });
 
     it("手札1枚でもドロー後に2枚捨てられるため発動可能", () => {
       duelState.hands = [
-        { id: 79571449, name: "天使の施し", type: "spell", description: "デッキから3枚ドローし、その後手札から2枚捨てる" },
-        { id: 10, name: "手札1", type: "monster", description: "手札のカード1" }
+        {
+          id: 79571449,
+          name: "天使の施し",
+          type: "spell",
+          description: "デッキから3枚ドローし、その後手札から2枚捨てる",
+        },
+        { id: 10, name: "手札1", type: "monster", description: "手札のカード1" },
       ];
       // 2 + 3 = 5枚 → 2枚捨てる可能
       expect(gracefulCharityEffect.canActivate(duelState)).toBe(true);
@@ -148,7 +165,14 @@ describe("GracefulCharityEffect", () => {
     });
 
     it("手札0枚でも正常に実行される", async () => {
-      duelState.hands = [{ id: 79571449, name: "天使の施し", type: "spell", description: "デッキから3枚ドローし、その後手札から2枚捨てる" }]; // 天使の施しのみ
+      duelState.hands = [
+        {
+          id: 79571449,
+          name: "天使の施し",
+          type: "spell",
+          description: "デッキから3枚ドローし、その後手札から2枚捨てる",
+        },
+      ]; // 天使の施しのみ
       const initialDeckSize = duelState.mainDeck.length; // 6枚
       const initialGraveyardSize = duelState.graveyard.length; // 0枚
 
@@ -169,8 +193,13 @@ describe("GracefulCharityEffect", () => {
 
     it("手札1枚でも正常に実行される", async () => {
       duelState.hands = [
-        { id: 79571449, name: "天使の施し", type: "spell", description: "デッキから3枚ドローし、その後手札から2枚捨てる" },
-        { id: 10, name: "手札1", type: "monster", description: "手札のカード1" }
+        {
+          id: 79571449,
+          name: "天使の施し",
+          type: "spell",
+          description: "デッキから3枚ドローし、その後手札から2枚捨てる",
+        },
+        { id: 10, name: "手札1", type: "monster", description: "手札のカード1" },
       ];
       const initialDeckSize = duelState.mainDeck.length; // 6枚
       const initialGraveyardSize = duelState.graveyard.length; // 0枚

--- a/skeleton-app/src/lib/classes/effects/cards/__tests__/PotOfGreedEffect.test.ts
+++ b/skeleton-app/src/lib/classes/effects/cards/__tests__/PotOfGreedEffect.test.ts
@@ -16,9 +16,7 @@ describe("PotOfGreedEffect", () => {
         { id: 4, name: "聖なるバリア", type: "trap", description: "攻撃無効化" },
         { id: 5, name: "サンダーボルト", type: "spell", description: "全体除去" },
       ],
-      hands: [
-        { id: 55144522, name: "強欲な壺", type: "spell", description: "デッキから2枚ドローする" },
-      ],
+      hands: [{ id: 55144522, name: "強欲な壺", type: "spell", description: "デッキから2枚ドローする" }],
     });
 
     // 現在のフェイズとゲーム結果を設定
@@ -145,7 +143,7 @@ describe("PotOfGreedEffect", () => {
       // 手札に複数の強欲な壺を追加
       duelState.hands.push(
         { id: 55144522, name: "強欲な壺", type: "spell", description: "デッキから2枚ドローする" },
-        { id: 55144522, name: "強欲な壺", type: "spell", description: "デッキから2枚ドローする" }
+        { id: 55144522, name: "強欲な壺", type: "spell", description: "デッキから2枚ドローする" },
       );
 
       // 1回目: 初期手札3枚、実行後 3-1+2=4枚

--- a/skeleton-app/src/lib/classes/effects/cards/magic/normal/PotOfGreedEffect.ts
+++ b/skeleton-app/src/lib/classes/effects/cards/magic/normal/PotOfGreedEffect.ts
@@ -37,11 +37,11 @@ export class PotOfGreedEffect extends BaseMagicEffect {
   /**
    * 魔法効果の解決: 2枚ドロー
    */
-  protected resolveMagicEffect(state: DuelState): EffectResult {
+  protected async resolveMagicEffect(state: DuelState): Promise<EffectResult> {
     console.log(`[${this.name}] 効果解決: 2枚ドロー`);
 
     // ドロー効果を実行
-    const drawResult = this.drawEffect.execute(state);
+    const drawResult = await this.drawEffect.execute(state);
 
     if (!drawResult.success) {
       return this.createErrorResult(`${this.name}: ${drawResult.message}`);

--- a/skeleton-app/src/lib/classes/effects/primitives/DiscardEffect.ts
+++ b/skeleton-app/src/lib/classes/effects/primitives/DiscardEffect.ts
@@ -47,7 +47,7 @@ export class DiscardEffect extends BaseEffect {
    * 効果実行: 手札から指定枚数を墓地に送る
    * 現在の実装では手札の最後からカードを捨てる（ランダム性は将来的に実装）
    */
-  execute(state: DuelState): EffectResult {
+  async execute(state: DuelState): Promise<EffectResult> {
     console.log(`[${this.name}] 手札から${this.discardCount}枚捨てる効果を実行します`);
 
     // 発動条件の再チェック

--- a/skeleton-app/src/lib/classes/effects/primitives/DrawEffect.ts
+++ b/skeleton-app/src/lib/classes/effects/primitives/DrawEffect.ts
@@ -27,7 +27,7 @@ export class DrawEffect extends BaseEffect {
    * ドロー効果を実行
    * 指定された枚数のカードをデッキからドローする
    */
-  execute(state: DuelState): EffectResult {
+  async execute(state: DuelState): Promise<EffectResult> {
     if (!this.canActivate(state)) {
       return this.createErrorResult(
         `デッキに${this.drawCount}枚のカードがありません（残り${state.mainDeck.length}枚）`,

--- a/skeleton-app/src/lib/classes/effects/primitives/__tests__/DrawEffect.test.ts
+++ b/skeleton-app/src/lib/classes/effects/primitives/__tests__/DrawEffect.test.ts
@@ -63,11 +63,11 @@ describe("DrawEffect", () => {
   });
 
   describe("効果実行", () => {
-    it("2枚ドロー効果が正常に動作する", () => {
+    it("2枚ドロー効果が正常に動作する", async () => {
       const initialHandSize = duelState.hands.length;
       const initialDeckSize = duelState.mainDeck.length;
 
-      const result = drawEffect2.execute(duelState);
+      const result = await drawEffect2.execute(duelState);
 
       expect(result.success).toBe(true);
       expect(result.message).toBe("2枚ドローしました");
@@ -79,11 +79,11 @@ describe("DrawEffect", () => {
       expect(duelState.mainDeck.length).toBe(initialDeckSize - 2);
     });
 
-    it("1枚ドロー効果が正常に動作する", () => {
+    it("1枚ドロー効果が正常に動作する", async () => {
       const initialHandSize = duelState.hands.length;
       const initialDeckSize = duelState.mainDeck.length;
 
-      const result = drawEffect1.execute(duelState);
+      const result = await drawEffect1.execute(duelState);
 
       expect(result.success).toBe(true);
       expect(result.message).toBe("1枚ドローしました");
@@ -91,11 +91,11 @@ describe("DrawEffect", () => {
       expect(duelState.mainDeck.length).toBe(initialDeckSize - 1);
     });
 
-    it("ドローしたカードが手札に正しく追加される", () => {
+    it("ドローしたカードが手札に正しく追加される", async () => {
       // デッキの上2枚を記録
       const topCards = duelState.mainDeck.slice(-2);
 
-      const result = drawEffect2.execute(duelState);
+      const result = await drawEffect2.execute(duelState);
 
       expect(result.success).toBe(true);
       expect(result.affectedCards).toEqual(topCards.reverse()); // drawCardは後ろから取るので逆順
@@ -105,21 +105,21 @@ describe("DrawEffect", () => {
       expect(lastTwoHands).toEqual(topCards);
     });
 
-    it("発動不可能な状態で実行すると失敗する", () => {
+    it("発動不可能な状態で実行すると失敗する", async () => {
       duelState.mainDeck = [{ id: 1, name: "カード1", type: "monster", description: "テスト1" }];
 
-      const result = drawEffect2.execute(duelState);
+      const result = await drawEffect2.execute(duelState);
 
       expect(result.success).toBe(false);
       expect(result.message).toContain("デッキに2枚のカードがありません");
       expect(result.stateChanged).toBe(false);
     });
 
-    it("デッキが不足している場合は適切なエラーメッセージを返す", () => {
+    it("デッキが不足している場合は適切なエラーメッセージを返す", async () => {
       // デッキを1枚にして2枚ドローを試行
       duelState.mainDeck = [{ id: 1, name: "カード1", type: "monster", description: "テスト1" }];
 
-      const result = drawEffect2.execute(duelState);
+      const result = await drawEffect2.execute(duelState);
 
       expect(result.success).toBe(false);
       expect(result.message).toContain("デッキに2枚のカードがありません");

--- a/skeleton-app/src/lib/types/effect.ts
+++ b/skeleton-app/src/lib/types/effect.ts
@@ -51,7 +51,7 @@ export interface Effect {
    * @param state 現在のデュエル状態
    * @returns 実行結果
    */
-  execute(state: DuelState): EffectResult | Promise<EffectResult>;
+  execute(state: DuelState): Promise<EffectResult>;
 }
 
 /**


### PR DESCRIPTION
## Summary
- BaseEffect.executeをasync化してPromise<EffectResult>を返すよう統一
- DrawEffect、DiscardEffectをasync化
- PotOfGreedEffect内のawait呼び出しに対応  
- BaseMagicEffect.resolveMagicEffectをPromise<EffectResult>に統一
- すべてのテストコードを非同期対応に修正

## 変更理由
- UIインタラクション（カード選択など）で非同期処理が必要
- API設計の一貫性向上（`EffectResult | Promise<EffectResult>`から`Promise<EffectResult>`に統一）
- 型安全性の向上（union型を廃止）

## Test plan
- [x] 型チェックが通ることを確認
- [x] ビルドが成功することを確認
- [x] リントとフォーマットが通ることを確認
- [ ] 既存のテストがすべて通ることを確認
- [ ] 実際の効果実行が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)